### PR TITLE
Allocate input buffer on demand

### DIFF
--- a/src/msspi.cpp
+++ b/src/msspi.cpp
@@ -538,7 +538,6 @@ struct MSSPI
         grbitEnabledProtocols = 0;
         dtls_mtu = 0;
         srtp_profile = 0;
-        in_buf.resize( MSSPI_BASE_BUFFER_SIZE );
     }
 
     ~MSSPI()


### PR DESCRIPTION
Remove the eager input buffer allocation from the handle constructor. Input paths already ensure the required buffer size before use.

Tested with the C++11 default, CAPIX, and MSSPI_CERT builds.